### PR TITLE
Use componentWillReceiveProps to prevent double rendering

### DIFF
--- a/src/components/notes/NoteForm.js
+++ b/src/components/notes/NoteForm.js
@@ -46,13 +46,13 @@ class NoteForm extends React.Component {
     })
   }
 
-  componentDidUpdate(prevProps, prevState) {
+  componentWillReceiveProps(nextProps) {
     const {
       data,
       noteId
     } = this.props
 
-    if (prevProps.noteId !== noteId) {
+    if (nextProps.noteId !== noteId) {
       this.setState({
         title: data[noteId].title,
         content: data[noteId].content,


### PR DESCRIPTION
Changing state in `componentDidMount` causes for the components to render twice. So, we have to change state before `render` triggered. We can do it on `componentWillReceiveProps`.

But, you've done great job. 😎 😎 😎 